### PR TITLE
Fixed broken link to CP210x drivers

### DIFF
--- a/docs/Lesson_01/lesson.md
+++ b/docs/Lesson_01/lesson.md
@@ -30,7 +30,7 @@ The most common additional drivers you may want to install are:
 * CH340/341 drivers - [Windows](http://www.wch.cn/download/CH341SER_ZIP.html), [OSX](http://www.wch.cn/download/CH341SER_MAC_ZIP.html)
   * This will be required if you're using the [Gizwits Witty](../Witty/info.html) and some [NodeMCU](../NodeMCU/info.html) modules
 * FT232x drivers - [All OS](http://www.ftdichip.com/Drivers/VCP.htm)
-* CP210x drivers - [All OS](http://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx)
+* CP210x drivers - [All OS](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)
   * This will be required if for some [NodeMCU](../NodeMCU/info.html) modules
 
 


### PR DESCRIPTION
I was going through the tutorial just now and found a broken link.  I think this is the updated one.